### PR TITLE
Pinning to an earlier version of the Gatling image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,7 +122,7 @@ pipeline {
         stage('Gatling performance test') {
             agent {
                 docker {
-                    image 'denvazh/gatling'
+                    image 'denvazh/gatling:2.2.5'
                     args "-u 0:0 --net demo"
                     reuseNode true
                 }


### PR DESCRIPTION
This version of the Gatling image uses a different version of Scala that matches the test we have.